### PR TITLE
Use erlfmt for formatting

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,10 +1,12 @@
 {erl_opts, [debug_info]}.
 {deps, [
-  {gun, {git, "https://github.com/ninenines/gun.git", {tag, "2.1.0"}}}
-  ]}.
-
+    {gun, {git, "https://github.com/ninenines/gun.git", {tag, "2.1.0"}}}
+]}.
 
 {shell, [
     {config, "config/sys.config"},
     {apps, [erdi]}
 ]}.
+
+{project_plugins, [erlfmt]}.
+{erlfmt, [write]}.


### PR DESCRIPTION
Enable erlfmt for rebar3. Remember to run erlfmt
before commiting.