### PR TITLE
Handle the READY message

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -1,10 +1,9 @@
  [ {erdi, [
-%   {gateway_tls, [{verify, verify_peer}, {cacerts, public_key:cacerts_get()}]},
     {gateway_domain, "discord.com"},
-    {port, 443},
     {gateway_path, "/api/gateway"},
-%    {websocket_tls, [{verify, verify_none}, {cacerts, public_key:cacerts_get()}]},
-    {websocket_protocols, [http]},
-    {websocket_path, "/?v=10"}
+    {port, 443},
+    {ws_protocols, [http]},
+    {ws_path, "/?v=10"},
+    {intents, 513}
   ]}].
  


### PR DESCRIPTION
All op 0 messages now get postponed to the ready state. The READY message gets parsed a bit.
Some name changes to avoid so much typing.

TODO:   The ready state is somewhat misnamed now.
        Perhaps "active" or "listening"
        Can the json lib turn those keys into atoms?
        Where should the non-ready op 0 messages go?